### PR TITLE
Find the correct zone before attempting to get rrsets

### DIFF
--- a/pdns/pipe-yang-backend.py
+++ b/pdns/pipe-yang-backend.py
@@ -171,8 +171,8 @@ class YANGBackend:
         the PowerDNS pipe ABI version 2. After writing all of the responses,
         indicates to PowerDNS that there is no more data by writing "END".
 
-	If in doubt about the parameter types, please refer to the PowerDNS
-	pipe backend documentation at https://doc.powerdns.com/authoritative/backends/pipe.html
+        If in doubt about the parameter types, please refer to the PowerDNS
+        pipe backend documentation at https://doc.powerdns.com/authoritative/backends/pipe.html
 
         :param str qname: DNS resource name
         :param str qclass: DNS class

--- a/pdns/pipe-yang-backend.py
+++ b/pdns/pipe-yang-backend.py
@@ -174,7 +174,7 @@ class YANGBackend:
         domain = qname
 
         while domain != '':
-            domain_xpath = '{zone_xpath}[domain="{domain}"]/rrset[type="SOA"]/rdata[text()]'.format(
+            domain_xpath = '{zone_xpath}[domain="{domain}"]/rrset[type="SOA"][owner="{domain}"]/rdata[text()]'.format(
                 zone_xpath=self.zone_xpath,
                 domain=domain)
             vals = self.get_config_data(domain_xpath)
@@ -224,8 +224,9 @@ class YANGBackend:
         # FIXME: we can probably do this all in one XPath query if we're clever
         #        about it
         for qtype in qtypes:
-            select_xpath = '{record_xpath}/rrset[type="{qtype}"]/rdata[text()]'.format(
+            select_xpath = '{record_xpath}/rrset[type="{qtype}"][owner="{qname}"]/rdata[text()]'.format(
                     record_xpath=record_xpath,
+                    qname=qname,
                     qtype=qtype)
 
             # FIXME: stub/mock for unit testing (this seems like the right


### PR DESCRIPTION
Before, we used to use the full qname as the zone-name. However, this is of course not the case for in-zone records :smile: 