### PR TITLE
Implement AXFR support

### DIFF
--- a/pdns/pipe-yang-backend.py
+++ b/pdns/pipe-yang-backend.py
@@ -34,6 +34,8 @@ pdns.conf should have lines similar to this:
 launch=pipe
 pipe-abi-version=2
 pipe-command=/path/to/pipe-yang-backend.py
+
+To support AXFR requests, set 'pipe-abi-version' to 4.
 """
 
 class YANGBackend:


### PR DESCRIPTION
This PR adds ABI version 4 support and AXFR support on to of that.

The code now uses an XPATH expression to retrieve the tree at `/dns-server-amended-with-zone:dns-server/zones/zone[domain='$DOMAIN']` and iterates over the children of that note to gather the data it needs.